### PR TITLE
viewer.git to viewerjs.git

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ dist/
 Four quick start options are available:
 
 - [Download the latest release](https://github.com/fengyuanchen/viewer/archive/master.zip).
-- Clone the repository: `git clone https://github.com/fengyuanchen/viewer.git`.
+- Clone the repository: `git clone https://github.com/fengyuanchen/viewerjs.git`.
 - Install with [NPM](http://npmjs.org): `npm install viewerjs`.
 - Install with [Bower](http://bower.io): `bower install fengyuanchen/viewerjs`.
 


### PR DESCRIPTION
Probably a left over type from a rename?