### PR TITLE
Add 'flippable' setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,14 @@ Enable to rotate the image.
 Enable to scale the image.
 
 
+### flippable
+
+- Type: `Boolean`
+- Default: `true`
+
+Enable to flip the image over. Needs also `scalable` turned on.
+
+
 ### transition
 
 - Type: `Boolean`

--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -29,6 +29,9 @@ export default {
   // Enable to scale the image
   scalable: true,
 
+  // Enable to flip the image over
+  flippable: true,
+
   // Enable CSS3 Transition for some special elements
   transition: true,
 

--- a/src/js/viewer.js
+++ b/src/js/viewer.js
@@ -138,7 +138,7 @@ class Viewer {
 
     $.toggleClass(toolbar.querySelector('.viewer-one-to-one'), 'viewer-invisible', !options.zoomable);
     $.toggleClass(toolbar.querySelectorAll('li[class*="zoom"]'), 'viewer-invisible', !options.zoomable);
-    $.toggleClass(toolbar.querySelectorAll('li[class*="flip"]'), 'viewer-invisible', !options.scalable);
+    $.toggleClass(toolbar.querySelectorAll('li[class*="flip"]'), 'viewer-invisible', !options.flippable || !options.scalable);
 
     if (!options.rotatable) {
       const rotates = toolbar.querySelectorAll('li[class*="rotate"]');


### PR DESCRIPTION
It seems to me that the setting called 'scalable' is rather confusing because apart from its intrinsic function it also enables and disables buttons which flips the image horizontally or vertically. So I've added one more setting ('flippable') whose role is to solely show and hide flipping buttons. The code deciding whether the flipping buttons should be shown or not also respects 'scalable' setting due to the fact that flipping uses scaling in itself.
What do you think?