### PR TITLE
fix that document.body may be null/undefined

### DIFF
--- a/src/js/others.js
+++ b/src/js/others.js
@@ -28,6 +28,9 @@ export default {
 
   close() {
     const { body } = this;
+    if (!body) {
+      return;
+    }
 
     removeClass(body, CLASS_OPEN);
     body.style.paddingRight = this.initialBodyPaddingRight;

--- a/src/js/viewer.js
+++ b/src/js/viewer.js
@@ -118,7 +118,7 @@ class Viewer {
     this.count = 0;
     this.images = images;
 
-    const { body } = document;
+    const body = document.body || document.documentElement;
 
     this.body = body;
     this.scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;


### PR DESCRIPTION
The first commit uses `documentElement` if `document.body` is `null` - if host js code calls `document.body.remove()`.

The second commit fix a crash that happens if `this.init()` returns too early (e.g. no images), addressing an issue mentioned in https://github.com/fengyuanchen/viewerjs/pull/77#issuecomment-348443283 .