### PR TITLE
build: use `+` for ES6 template literals

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,6 +7,11 @@
       }
     ]
   ],
+  "plugins": [
+    ["@babel/plugin-transform-template-literals", {
+      "loose": true
+    }]
+  ],
   "env": {
     "test": {
       "plugins": [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our [guidelines](https://github.com/fengyuanchen/viewerjs/blob/master/.github/CONTRIBUTING.md#commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update
[ ] Refactor
[x] Build related changes
[ ] Documentation content changes
[ ] Other, Please describe:
```


## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The behavior before is `"".concat(part1, part2, ...)`,
which is useless and makes the minified file larger (about 600 bytes).

The benefit of `concat` is just supporting `Symbol.toPrimitive`.

## What is the new behavior?

Therefore, we should replace it with simpler `+`.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Size comparision for minified files (the right side is made by this PR):

![image](https://user-images.githubusercontent.com/5547703/50574960-cbfa3380-0e2d-11e9-97bb-b3d546c8ab2d.png)
