### PR TITLE
Updata viewer.scss

### DIFF
--- a/src/css/viewer.scss
+++ b/src/css/viewer.scss
@@ -15,6 +15,7 @@
   &-close {
     &::before {
       background-image: url('../images/icons.png');
+      background-size: 280px;
       background-repeat: no-repeat;
       color: transparent;
       display: block;


### PR DESCRIPTION
修复移动端rem适配后，导致图片查看控件icon位置错乱问题，主要原因是sprite图没有定义大小，background-position的px被转换为rem单位后，图片的大小没有被转换，导致的position的定位错了，给sprite图设置了background-size的大小后，可修复这个问题。