### PR TITLE
fix: "alt" values were mistakenly escaped

### DIFF
--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -216,7 +216,7 @@ export default {
     const item = this.items[index];
     const img = item.querySelector('img');
     const url = getData(img, 'originalUrl');
-    const alt = escapeHTMLEntities(img.getAttribute('alt'));
+    const alt = img.getAttribute('alt');
     const image = document.createElement('img');
 
     image.src = url;
@@ -639,7 +639,7 @@ export default {
       const image = document.createElement('img');
 
       image.src = getData(img, 'originalUrl');
-      image.alt = escapeHTMLEntities(img.getAttribute('alt'));
+      image.alt = img.getAttribute('alt');
       total += 1;
       addClass(image, CLASS_FADE);
       toggleClass(image, CLASS_TRANSITION, options.transition);

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -9,7 +9,6 @@ import {
   addClass,
   addListener,
   assign,
-  escapeHTMLEntities,
   forEach,
   getImageNameFromURL,
   getImageNaturalSizes,
@@ -66,10 +65,12 @@ export default {
   initList() {
     const { element, options, list } = this;
     const items = [];
+    // initList may be called in this.update, so should keep idempotent
+    list.innerHTML = '';
 
     forEach(this.images, (image, index) => {
       const { src } = image;
-      const alt = escapeHTMLEntities(image.alt || getImageNameFromURL(src));
+      const alt = image.alt || getImageNameFromURL(src);
       let { url } = options;
 
       if (isString(url)) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

The commit ddd0c3d515dd1d8ea3e0323f486fab7d2cd5631f has such bugs:
* makes the alt property something like "`&lt;test1&gt;`" .
* `this.list` may be filled more than once

This PR fixes them.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome 76.0.3809.80 x64 on Win 10
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

