### PR TITLE
fix: wrong usage about `this` in ES6+

### DIFF
--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -158,7 +158,7 @@ export default {
       };
 
       this.transitioning = {
-        abort() {
+        abort: () => {
           if (this.viewed) {
             removeListener(this.image, EVENT_TRANSITION_END, hide);
           } else {
@@ -280,7 +280,7 @@ export default {
     });
 
     this.viewing = {
-      abort() {
+      abort: () => {
         removeListener(element, EVENT_VIEWED, onViewed);
 
         if (image.complete) {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

In some `abort` functions, `this` in ES6 member functions pointed to its state object, but not a `Viewer`. This PR fixes it.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot: No

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome 83 x64 on Win 10
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
