### PR TITLE
feat: add new 'edgeLimit' option

### DIFF
--- a/dist/viewer.common.js
+++ b/dist/viewer.common.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-11-08T05:28:37.365Z
+ * Date: 2020-12-01T01:27:02.286Z
  */
 
 'use strict';
@@ -309,6 +309,18 @@ var DEFAULTS = {
    * @type {string | Function}
    */
   url: 'src',
+
+  /**
+   * Enable edge limitation on move.
+   * @type {boolean}
+   */
+  edgeLimit: false,
+
+  /**
+   * Define edge limit ratio based on current image width.
+   * @type {number}
+   */
+  edgeRatio: 0.5,
 
   /**
    * Event shortcuts.
@@ -1013,6 +1025,43 @@ function getPointersCenter(pointers) {
   return {
     pageX: pageX,
     pageY: pageY
+  };
+}
+/**
+ * Limit the image to an edge point.
+ * @param {Viewer} viewer - Viewer Object
+ * @param {number} left - The x-axis coordinate.
+ * @param {number} top - The y-axis coordinate.
+ * @returns {Object} - The result x and y-axis based on edge limitation.
+ */
+
+function edgeThresholdValue(viewer, left, top) {
+  var imageData = viewer.imageData,
+      viewerData = viewer.viewerData,
+      options = viewer.options;
+  var edgeRatio = options.edgeRatio;
+  var widthLimiter = imageData.width * edgeRatio;
+  var heightLimiter = imageData.height * edgeRatio;
+
+  if (left < -widthLimiter) {
+    left = -widthLimiter;
+  }
+
+  if (left > viewerData.width - widthLimiter) {
+    left = viewerData.width - widthLimiter;
+  }
+
+  if (top < -heightLimiter) {
+    top = -heightLimiter;
+  }
+
+  if (top > viewerData.height - heightLimiter) {
+    top = viewerData.height - heightLimiter;
+  }
+
+  return {
+    left: left,
+    top: top
   };
 }
 
@@ -2127,20 +2176,28 @@ var methods = {
    */
   moveTo: function moveTo(x) {
     var y = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : x;
-    var imageData = this.imageData;
+    var imageData = this.imageData,
+        options = this.options;
     x = Number(x);
     y = Number(y);
+
+    var _ref = options.edgeLimit ? edgeThresholdValue(this, x, y) : {
+      left: x,
+      top: y
+    },
+        left = _ref.left,
+        top = _ref.top;
 
     if (this.viewed && !this.played && this.options.movable) {
       var changed = false;
 
-      if (isNumber(x)) {
-        imageData.left = x;
+      if (isNumber(left)) {
+        imageData.left = left;
         changed = true;
       }
 
-      if (isNumber(y)) {
-        imageData.top = y;
+      if (isNumber(top)) {
+        imageData.top = top;
         changed = true;
       }
 
@@ -3343,3 +3400,4 @@ var Viewer = /*#__PURE__*/function () {
 assign(Viewer.prototype, render, events, handlers, methods, others);
 
 module.exports = Viewer;
+//# sourceMappingURL=viewer.common.js.map

--- a/dist/viewer.esm.js
+++ b/dist/viewer.esm.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-11-08T05:28:37.365Z
+ * Date: 2020-12-01T01:27:02.286Z
  */
 
 function _typeof(obj) {
@@ -307,6 +307,18 @@ var DEFAULTS = {
    * @type {string | Function}
    */
   url: 'src',
+
+  /**
+   * Enable edge limitation on move.
+   * @type {boolean}
+   */
+  edgeLimit: false,
+
+  /**
+   * Define edge limit ratio based on current image width.
+   * @type {number}
+   */
+  edgeRatio: 0.5,
 
   /**
    * Event shortcuts.
@@ -1011,6 +1023,43 @@ function getPointersCenter(pointers) {
   return {
     pageX: pageX,
     pageY: pageY
+  };
+}
+/**
+ * Limit the image to an edge point.
+ * @param {Viewer} viewer - Viewer Object
+ * @param {number} left - The x-axis coordinate.
+ * @param {number} top - The y-axis coordinate.
+ * @returns {Object} - The result x and y-axis based on edge limitation.
+ */
+
+function edgeThresholdValue(viewer, left, top) {
+  var imageData = viewer.imageData,
+      viewerData = viewer.viewerData,
+      options = viewer.options;
+  var edgeRatio = options.edgeRatio;
+  var widthLimiter = imageData.width * edgeRatio;
+  var heightLimiter = imageData.height * edgeRatio;
+
+  if (left < -widthLimiter) {
+    left = -widthLimiter;
+  }
+
+  if (left > viewerData.width - widthLimiter) {
+    left = viewerData.width - widthLimiter;
+  }
+
+  if (top < -heightLimiter) {
+    top = -heightLimiter;
+  }
+
+  if (top > viewerData.height - heightLimiter) {
+    top = viewerData.height - heightLimiter;
+  }
+
+  return {
+    left: left,
+    top: top
   };
 }
 
@@ -2125,20 +2174,28 @@ var methods = {
    */
   moveTo: function moveTo(x) {
     var y = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : x;
-    var imageData = this.imageData;
+    var imageData = this.imageData,
+        options = this.options;
     x = Number(x);
     y = Number(y);
+
+    var _ref = options.edgeLimit ? edgeThresholdValue(this, x, y) : {
+      left: x,
+      top: y
+    },
+        left = _ref.left,
+        top = _ref.top;
 
     if (this.viewed && !this.played && this.options.movable) {
       var changed = false;
 
-      if (isNumber(x)) {
-        imageData.left = x;
+      if (isNumber(left)) {
+        imageData.left = left;
         changed = true;
       }
 
-      if (isNumber(y)) {
-        imageData.top = y;
+      if (isNumber(top)) {
+        imageData.top = top;
         changed = true;
       }
 
@@ -3341,3 +3398,4 @@ var Viewer = /*#__PURE__*/function () {
 assign(Viewer.prototype, render, events, handlers, methods, others);
 
 export default Viewer;
+//# sourceMappingURL=viewer.esm.js.map

--- a/dist/viewer.js
+++ b/dist/viewer.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-11-08T05:28:37.365Z
+ * Date: 2020-12-01T01:27:02.286Z
  */
 
 (function (global, factory) {
@@ -313,6 +313,18 @@
      * @type {string | Function}
      */
     url: 'src',
+
+    /**
+     * Enable edge limitation on move.
+     * @type {boolean}
+     */
+    edgeLimit: false,
+
+    /**
+     * Define edge limit ratio based on current image width.
+     * @type {number}
+     */
+    edgeRatio: 0.5,
 
     /**
      * Event shortcuts.
@@ -1017,6 +1029,43 @@
     return {
       pageX: pageX,
       pageY: pageY
+    };
+  }
+  /**
+   * Limit the image to an edge point.
+   * @param {Viewer} viewer - Viewer Object
+   * @param {number} left - The x-axis coordinate.
+   * @param {number} top - The y-axis coordinate.
+   * @returns {Object} - The result x and y-axis based on edge limitation.
+   */
+
+  function edgeThresholdValue(viewer, left, top) {
+    var imageData = viewer.imageData,
+        viewerData = viewer.viewerData,
+        options = viewer.options;
+    var edgeRatio = options.edgeRatio;
+    var widthLimiter = imageData.width * edgeRatio;
+    var heightLimiter = imageData.height * edgeRatio;
+
+    if (left < -widthLimiter) {
+      left = -widthLimiter;
+    }
+
+    if (left > viewerData.width - widthLimiter) {
+      left = viewerData.width - widthLimiter;
+    }
+
+    if (top < -heightLimiter) {
+      top = -heightLimiter;
+    }
+
+    if (top > viewerData.height - heightLimiter) {
+      top = viewerData.height - heightLimiter;
+    }
+
+    return {
+      left: left,
+      top: top
     };
   }
 
@@ -2131,20 +2180,28 @@
      */
     moveTo: function moveTo(x) {
       var y = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : x;
-      var imageData = this.imageData;
+      var imageData = this.imageData,
+          options = this.options;
       x = Number(x);
       y = Number(y);
+
+      var _ref = options.edgeLimit ? edgeThresholdValue(this, x, y) : {
+        left: x,
+        top: y
+      },
+          left = _ref.left,
+          top = _ref.top;
 
       if (this.viewed && !this.played && this.options.movable) {
         var changed = false;
 
-        if (isNumber(x)) {
-          imageData.left = x;
+        if (isNumber(left)) {
+          imageData.left = left;
           changed = true;
         }
 
-        if (isNumber(y)) {
-          imageData.top = y;
+        if (isNumber(top)) {
+          imageData.top = top;
           changed = true;
         }
 
@@ -3349,3 +3406,4 @@
   return Viewer;
 
 })));
+//# sourceMappingURL=viewer.js.map

--- a/docs/css/viewer.css
+++ b/docs/css/viewer.css
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-11-08T05:28:32.068Z
+ * Date: 2020-12-01T01:27:02.712Z
  */
 
 .viewer-zoom-in::before,

--- a/docs/index.html
+++ b/docs/index.html
@@ -211,6 +211,12 @@
               </li>
               <li class="list-group-item">
                 <div class="form-check">
+                  <input class="form-check-input" id="edgeLimit" type="checkbox" name="edgeLimit">
+                  <label for="edgeLimit" class="form-check-label">edgeLimit</label>
+                </div>
+              </li>
+              <li class="list-group-item">
+                <div class="form-check">
                   <input class="form-check-input" id="zoomOnWheel" type="checkbox" name="zoomOnWheel" checked>
                   <label for="zoomOnWheel" class="form-check-label">zoomOnWheel</label>
                 </div>

--- a/docs/js/viewer.js
+++ b/docs/js/viewer.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2020-11-08T05:28:37.365Z
+ * Date: 2020-12-01T01:27:02.286Z
  */
 
 (function (global, factory) {
@@ -313,6 +313,18 @@
      * @type {string | Function}
      */
     url: 'src',
+
+    /**
+     * Enable edge limitation on move.
+     * @type {boolean}
+     */
+    edgeLimit: false,
+
+    /**
+     * Define edge limit ratio based on current image width.
+     * @type {number}
+     */
+    edgeRatio: 0.5,
 
     /**
      * Event shortcuts.
@@ -1017,6 +1029,43 @@
     return {
       pageX: pageX,
       pageY: pageY
+    };
+  }
+  /**
+   * Limit the image to an edge point.
+   * @param {Viewer} viewer - Viewer Object
+   * @param {number} left - The x-axis coordinate.
+   * @param {number} top - The y-axis coordinate.
+   * @returns {Object} - The result x and y-axis based on edge limitation.
+   */
+
+  function edgeThresholdValue(viewer, left, top) {
+    var imageData = viewer.imageData,
+        viewerData = viewer.viewerData,
+        options = viewer.options;
+    var edgeRatio = options.edgeRatio;
+    var widthLimiter = imageData.width * edgeRatio;
+    var heightLimiter = imageData.height * edgeRatio;
+
+    if (left < -widthLimiter) {
+      left = -widthLimiter;
+    }
+
+    if (left > viewerData.width - widthLimiter) {
+      left = viewerData.width - widthLimiter;
+    }
+
+    if (top < -heightLimiter) {
+      top = -heightLimiter;
+    }
+
+    if (top > viewerData.height - heightLimiter) {
+      top = viewerData.height - heightLimiter;
+    }
+
+    return {
+      left: left,
+      top: top
     };
   }
 
@@ -2131,20 +2180,28 @@
      */
     moveTo: function moveTo(x) {
       var y = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : x;
-      var imageData = this.imageData;
+      var imageData = this.imageData,
+          options = this.options;
       x = Number(x);
       y = Number(y);
+
+      var _ref = options.edgeLimit ? edgeThresholdValue(this, x, y) : {
+        left: x,
+        top: y
+      },
+          left = _ref.left,
+          top = _ref.top;
 
       if (this.viewed && !this.played && this.options.movable) {
         var changed = false;
 
-        if (isNumber(x)) {
-          imageData.left = x;
+        if (isNumber(left)) {
+          imageData.left = left;
           changed = true;
         }
 
-        if (isNumber(y)) {
-          imageData.top = y;
+        if (isNumber(top)) {
+          imageData.top = top;
           changed = true;
         }
 
@@ -3349,3 +3406,4 @@
   return Viewer;
 
 })));
+//# sourceMappingURL=viewer.js.map

--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -221,6 +221,18 @@ export default {
   url: 'src',
 
   /**
+   * Enable edge limitation on move.
+   * @type {boolean}
+   */
+  edgeLimit: false,
+
+  /**
+   * Define edge limit ratio based on current image width.
+   * @type {number}
+   */
+  edgeRatio: 0.5,
+
+  /**
    * Event shortcuts.
    * @type {Function}
    */

--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -40,6 +40,7 @@ import {
   removeListener,
   setStyle,
   toggleClass,
+  edgeThresholdValue,
 } from './utilities';
 
 export default {
@@ -406,21 +407,23 @@ export default {
    * @returns {Viewer} this
    */
   moveTo(x, y = x) {
-    const { imageData } = this;
+    const { imageData, options } = this;
 
     x = Number(x);
     y = Number(y);
 
+    const { left, top } = options.edgeLimit ? edgeThresholdValue(this, x, y) : { left: x, top: y };
+
     if (this.viewed && !this.played && this.options.movable) {
       let changed = false;
 
-      if (isNumber(x)) {
-        imageData.left = x;
+      if (isNumber(left)) {
+        imageData.left = left;
         changed = true;
       }
 
-      if (isNumber(y)) {
-        imageData.top = y;
+      if (isNumber(top)) {
+        imageData.top = top;
         changed = true;
       }
 

--- a/src/js/utilities.js
+++ b/src/js/utilities.js
@@ -675,3 +675,38 @@ export function getPointersCenter(pointers) {
     pageY,
   };
 }
+
+/**
+ * Limit the image to an edge point.
+ * @param {Viewer} viewer - Viewer Object
+ * @param {number} left - The x-axis coordinate.
+ * @param {number} top - The y-axis coordinate.
+ * @returns {Object} - The result x and y-axis based on edge limitation.
+ */
+export function edgeThresholdValue(viewer, left, top) {
+  const { imageData, viewerData, options } = viewer;
+  const { edgeRatio } = options;
+  const widthLimiter = imageData.width * edgeRatio;
+  const heightLimiter = imageData.height * edgeRatio;
+
+  if (left < -(widthLimiter)) {
+    left = -widthLimiter;
+  }
+
+  if (left > (viewerData.width - widthLimiter)) {
+    left = viewerData.width - widthLimiter;
+  }
+
+  if (top < -(heightLimiter)) {
+    top = -heightLimiter;
+  }
+
+  if (top > (viewerData.height - heightLimiter)) {
+    top = viewerData.height - heightLimiter;
+  }
+
+  return {
+    left,
+    top,
+  };
+}


### PR DESCRIPTION
fixed #352

added edgeLimit option to limit move event out of screen/container. default edgeRatio is 0.5 which based on moveable image.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [x] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
