### PR TITLE
修改typescript报错 问题

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,7 +21,7 @@ declare namespace Viewer {
     rotateRight?: ToolbarOption;
     zoomIn?: ToolbarOption;
     zoomOut?: ToolbarOption;
-    [x: string]: any;
+    [x: string]: ToolbarOption | undefined;
   }
 
   export interface MoveEventData {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,7 +21,7 @@ declare namespace Viewer {
     rotateRight?: ToolbarOption;
     zoomIn?: ToolbarOption;
     zoomOut?: ToolbarOption;
-    [x: string]: ToolbarOption;
+    [x: string]: any;
   }
 
   export interface MoveEventData {


### PR DESCRIPTION
> While string index signatures are a powerful way to describe the “dictionary” pattern, they also enforce that all properties match their return type. This is because a string index declares that obj.property is also available as obj["property"].

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ x ] Bugfix

