### PR TITLE
fix(render): resize error when item undefined

### DIFF
--- a/src/js/render.js
+++ b/src/js/render.js
@@ -160,6 +160,9 @@ export default {
   renderList() {
     const { index } = this;
     const item = this.items[index];
+    if (!item) {
+      return;
+    }
     const next = item.nextElementSibling;
     const gutter = parseInt(window.getComputedStyle(next || item).marginLeft, 10);
     const { offsetWidth } = item;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
- [x] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Steps:
1 Get a dom that has no`<img>` labels to `new Viewer()`.
For example: change the code of 'docs/coutom-title.html'

```html
<div id="galley">
<!-- remove children dom -->
</div>
```

``` javascript
window.addEventListener('DOMContentLoaded', function () {
    var galley = document.getElementById('galley');
    var viewer = new Viewer(galley, {
        url: 'data-original',
        title: function (image) {
          return image.alt + ' (' + (this.index + 1) + '/' + this.length + ')';
        },
    });
    // only add this code
    viewer.show();
});
```
2  Browse the 'coutom-title.html' in browser, resize the window, you will show the error console in DevTools.
```
// stack
viewer.js:1158 
    Uncaught TypeError: Cannot read properties of undefined (reading 'nextElementSibling')
    at Viewer.renderList (viewer.js:1158)
    at Viewer.resize (viewer.js:1748)
```