### PR TITLE
fix bug:When the bottom layer -webkit-app-region:drag is used, the vi…

### DIFF
--- a/src/css/viewer.css
+++ b/src/css/viewer.css
@@ -338,6 +338,7 @@
   top: -40px;
   transition: background-color 0.15s;
   width: 80px;
+  -webkit-app-region: no-drag;
 
   &:focus,
   &:hover {

--- a/src/css/viewer.scss
+++ b/src/css/viewer.scss
@@ -341,6 +341,7 @@
     top: -40px;
     transition: background-color 0.15s;
     width: 80px;
+    -webkit-app-region: no-drag;
 
     &:focus,
     &:hover {


### PR DESCRIPTION
When the bottom layer -webkit-app-region:drag is used, the viewer close button click is invalid in electron windows app

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
