### PR TITLE
feat: pass the future imageData object to the view callback #586

### DIFF
--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -259,10 +259,12 @@ export default {
       });
     }
 
+    const newImageData = {};
     if (dispatchEvent(element, EVENT_VIEW, {
       originalImage: this.images[index],
       index,
       image,
+      imageData: newImageData,
     }) === false || !this.isShown || this.hiding || this.played) {
       return this;
     }
@@ -284,7 +286,7 @@ export default {
     this.image = image;
     this.viewed = false;
     this.index = index;
-    this.imageData = {};
+    this.imageData = newImageData;
     addClass(image, CLASS_INVISIBLE);
 
     if (options.loading) {


### PR DESCRIPTION
This allows setting an initial rotation before an image is displayed.
Resolves #586

```js
new Viewer(dummyDiv, {
  // ...
  view: function (event) {
    event.detail.imageData.rotate = 90;
  },
```

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome 108
- [x] Firefox 110
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
