### PR TITLE
修复鸿蒙2.0发现点击图片外的遮罩层时有很大概率不会关闭预览的bug

### DIFF
--- a/dist/viewer.common.js
+++ b/dist/viewer.common.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2023-01-01T10:14:49.638Z
+ * Date: 2023-02-14T13:02:47.915Z
  */
 
 'use strict';
@@ -1497,6 +1497,11 @@ var handlers = {
       pointers = this.pointers;
     var buttons = event.buttons,
       button = event.button;
+    /** 记录位置 - @author Qiucl - 2023.02.14 */
+    this.pointerDownPosition = {
+      clientX: event.clientX,
+      clientY: event.clientY
+    };
     this.pointerMoved = false;
     if (!this.viewed || this.showing || this.viewing || this.hiding
 
@@ -1553,6 +1558,14 @@ var handlers = {
       action = this.action,
       pointers = this.pointers;
     var pointer;
+
+    /** 判断元素位置是否有变化 - @author Qiucl - 2023.02.14 */
+    var _this$pointerDownPosi = this.pointerDownPosition,
+      clientX = _this$pointerDownPosi.clientX,
+      clientY = _this$pointerDownPosi.clientY;
+    if (event.clientX === clientX && event.clientY === clientY) {
+      this.pointerMoved = false;
+    }
     if (event.changedTouches) {
       forEach(event.changedTouches, function (touch) {
         pointer = pointers[touch.identifier];
@@ -2963,6 +2976,16 @@ var Viewer = /*#__PURE__*/function () {
     this.wheeling = false;
     this.zooming = false;
     this.pointerMoved = false;
+    /**
+     * 记录按下时的位置, 在HarmonyOS 2.0自带webview发现会存在点击时就出发pointermove事件的bug, 其他系统未出现此bug;
+     * 此bug会导致点击图片外的遮罩层有很大概率无法关闭图片;
+     * 为解决bug所以增加这个属性, 判断pointerdown触发时的位置与pointerup触发的位置是否发生变化, 如果未发生变化就视为未移动, 此时如果click事件被触发就可以正常关闭图片预览
+     * @author Qiucl - 2023.02.14
+     */
+    this.pointerDownPosition = {
+      clientX: 0,
+      clientY: 0
+    };
     this.id = getUniqueID();
     this.init();
   }

--- a/dist/viewer.esm.js
+++ b/dist/viewer.esm.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2023-01-01T10:14:49.638Z
+ * Date: 2023-02-14T13:02:47.915Z
  */
 
 function ownKeys(object, enumerableOnly) {
@@ -1495,6 +1495,11 @@ var handlers = {
       pointers = this.pointers;
     var buttons = event.buttons,
       button = event.button;
+    /** 记录位置 - @author Qiucl - 2023.02.14 */
+    this.pointerDownPosition = {
+      clientX: event.clientX,
+      clientY: event.clientY
+    };
     this.pointerMoved = false;
     if (!this.viewed || this.showing || this.viewing || this.hiding
 
@@ -1551,6 +1556,14 @@ var handlers = {
       action = this.action,
       pointers = this.pointers;
     var pointer;
+
+    /** 判断元素位置是否有变化 - @author Qiucl - 2023.02.14 */
+    var _this$pointerDownPosi = this.pointerDownPosition,
+      clientX = _this$pointerDownPosi.clientX,
+      clientY = _this$pointerDownPosi.clientY;
+    if (event.clientX === clientX && event.clientY === clientY) {
+      this.pointerMoved = false;
+    }
     if (event.changedTouches) {
       forEach(event.changedTouches, function (touch) {
         pointer = pointers[touch.identifier];
@@ -2961,6 +2974,16 @@ var Viewer = /*#__PURE__*/function () {
     this.wheeling = false;
     this.zooming = false;
     this.pointerMoved = false;
+    /**
+     * 记录按下时的位置, 在HarmonyOS 2.0自带webview发现会存在点击时就出发pointermove事件的bug, 其他系统未出现此bug;
+     * 此bug会导致点击图片外的遮罩层有很大概率无法关闭图片;
+     * 为解决bug所以增加这个属性, 判断pointerdown触发时的位置与pointerup触发的位置是否发生变化, 如果未发生变化就视为未移动, 此时如果click事件被触发就可以正常关闭图片预览
+     * @author Qiucl - 2023.02.14
+     */
+    this.pointerDownPosition = {
+      clientX: 0,
+      clientY: 0
+    };
     this.id = getUniqueID();
     this.init();
   }

--- a/dist/viewer.js
+++ b/dist/viewer.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2023-01-01T10:14:49.638Z
+ * Date: 2023-02-14T13:02:47.915Z
  */
 
 (function (global, factory) {
@@ -1501,6 +1501,11 @@
         pointers = this.pointers;
       var buttons = event.buttons,
         button = event.button;
+      /** 记录位置 - @author Qiucl - 2023.02.14 */
+      this.pointerDownPosition = {
+        clientX: event.clientX,
+        clientY: event.clientY
+      };
       this.pointerMoved = false;
       if (!this.viewed || this.showing || this.viewing || this.hiding
 
@@ -1557,6 +1562,14 @@
         action = this.action,
         pointers = this.pointers;
       var pointer;
+
+      /** 判断元素位置是否有变化 - @author Qiucl - 2023.02.14 */
+      var _this$pointerDownPosi = this.pointerDownPosition,
+        clientX = _this$pointerDownPosi.clientX,
+        clientY = _this$pointerDownPosi.clientY;
+      if (event.clientX === clientX && event.clientY === clientY) {
+        this.pointerMoved = false;
+      }
       if (event.changedTouches) {
         forEach(event.changedTouches, function (touch) {
           pointer = pointers[touch.identifier];
@@ -2967,6 +2980,16 @@
       this.wheeling = false;
       this.zooming = false;
       this.pointerMoved = false;
+      /**
+       * 记录按下时的位置, 在HarmonyOS 2.0自带webview发现会存在点击时就出发pointermove事件的bug, 其他系统未出现此bug;
+       * 此bug会导致点击图片外的遮罩层有很大概率无法关闭图片;
+       * 为解决bug所以增加这个属性, 判断pointerdown触发时的位置与pointerup触发的位置是否发生变化, 如果未发生变化就视为未移动, 此时如果click事件被触发就可以正常关闭图片预览
+       * @author Qiucl - 2023.02.14
+       */
+      this.pointerDownPosition = {
+        clientX: 0,
+        clientY: 0
+      };
       this.id = getUniqueID();
       this.init();
     }

--- a/src/js/handlers.js
+++ b/src/js/handlers.js
@@ -336,6 +336,11 @@ export default {
   pointerdown(event) {
     const { options, pointers } = this;
     const { buttons, button } = event;
+    /** 记录位置 - @author Qiucl - 2023.02.14 */
+    this.pointerDownPosition = {
+        clientX: event.clientX,
+        clientY: event.clientY,
+    }
 
     this.pointerMoved = false;
 
@@ -411,6 +416,12 @@ export default {
   pointerup(event) {
     const { options, action, pointers } = this;
     let pointer;
+
+    /** 判断元素位置是否有变化 - @author Qiucl - 2023.02.14 */
+    const { clientX, clientY } = this.pointerDownPosition;
+    if(event.clientX === clientX && event.clientY === clientY){
+        this.pointerMoved = false;
+    }
 
     if (event.changedTouches) {
       forEach(event.changedTouches, (touch) => {

--- a/src/js/viewer.js
+++ b/src/js/viewer.js
@@ -85,6 +85,16 @@ class Viewer {
     this.wheeling = false;
     this.zooming = false;
     this.pointerMoved = false;
+    /**
+     * 记录按下时的位置, 在HarmonyOS 2.0自带webview发现会存在点击时就出发pointermove事件的bug, 其他系统未出现此bug;
+     * 此bug会导致点击图片外的遮罩层有很大概率无法关闭图片;
+     * 为解决bug所以增加这个属性, 判断pointerdown触发时的位置与pointerup触发的位置是否发生变化, 如果未发生变化就视为未移动, 此时如果click事件被触发就可以正常关闭图片预览
+     * @author Qiucl - 2023.02.14
+     */
+    this.pointerDownPosition = {
+        clientX: 0,
+        clientY: 0
+    }
     this.id = getUniqueID();
     this.init();
   }


### PR DESCRIPTION
原因是在鸿蒙2.0点击并且未移动图片时会触发pointermove, touchmove等move相关事件的bug, 导致pointerMoved为true引发无法关闭的问题.
其他浏览器经过测试在只点击且没有移动操作的情况下不会出现触发pointermove, touchmove等move相关的事件.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [x] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
