### PR TITLE
fix update() always reset index to 0

### DIFF
--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -1176,7 +1176,7 @@ export default {
 
         if (image && img) {
           if (
-            image.src !== img.src
+            image.src !== (img.src || img.dataset.originalUrl)
 
             // Title changed (#408)
             || image.alt !== img.alt


### PR DESCRIPTION
Due to only setting [the src attribute of the image](https://github.com/fengyuanchen/viewerjs/blob/main/src/js/render.js#L100) element when `navbar` is `true`(If navbar is `false`, [img.src](https://github.com/fengyuanchen/viewerjs/blob/main/src/js/methods.js#L1179) will always be an empty string.), this caused `changedIndexes` to be incorrectly assigned, which in turn caused the `update()` to reset the index to 0.

<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
<img width="1407" alt="image" src="https://user-images.githubusercontent.com/12773365/232010806-2d36fbfd-e05f-4289-b42b-574689a764fa.png">
