### PR TITLE
Fix #562 enhance zoom origin behavior when using icons in the control bar to zoom image

### DIFF
--- a/dist/viewer.common.js
+++ b/dist/viewer.common.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2023-09-17T03:16:38.052Z
+ * Date: 2023-10-20T01:08:38.355Z
  */
 
 'use strict';
@@ -1199,13 +1199,24 @@ var render = {
 
 var events = {
   bind: function bind() {
+    var _this = this;
     var options = this.options,
       viewer = this.viewer,
       canvas = this.canvas;
     var document = this.element.ownerDocument;
     addListener(viewer, EVENT_CLICK, this.onClick = this.click.bind(this));
     addListener(viewer, EVENT_DRAG_START, this.onDragStart = this.dragstart.bind(this));
-    addListener(canvas, EVENT_POINTER_DOWN, this.onPointerDown = this.pointerdown.bind(this));
+    // Use the new event binding to replace the original binding.
+    addListener(canvas, EVENT_POINTER_DOWN, function (event) {
+      _this.lastPointerPosition = {
+        x: event.pageX,
+        y: event.pageY
+      };
+      // Then call the original event handler function.
+      if (_this.pointerdown) {
+        _this.pointerdown(event);
+      }
+    });
     addListener(document, EVENT_POINTER_MOVE, this.onPointerMove = this.pointermove.bind(this));
     addListener(document, EVENT_POINTER_UP, this.onPointerUp = this.pointerup.bind(this));
     addListener(document, EVENT_KEY_DOWN, this.onKeyDown = this.keydown.bind(this));
@@ -2239,6 +2250,16 @@ var methods = {
       naturalWidth = imageData.naturalWidth,
       naturalHeight = imageData.naturalHeight;
     ratio = Math.max(0, ratio);
+
+    // After determining the zoom ratio, check if a pivot has already been provided. 
+    // If not, and we have the last pointerdown position, use it to set the pivot.
+    if (!pivot && this.lastPointerPosition) {
+      var offset = getOffset(this.viewer);
+      pivot = {
+        x: this.lastPointerPosition.x - offset.left,
+        y: this.lastPointerPosition.y - offset.top
+      };
+    }
     if (isNumber(ratio) && this.viewed && !this.played && (_zoomable || options.zoomable)) {
       if (!_zoomable) {
         var minZoomRatio = Math.max(0.01, options.minZoomRatio);
@@ -2280,15 +2301,15 @@ var methods = {
       }
       this.zooming = true;
       if (_originalEvent) {
-        var offset = getOffset(this.viewer);
+        var _offset = getOffset(this.viewer);
         var center = pointers && Object.keys(pointers).length > 0 ? getPointersCenter(pointers) : {
           pageX: _originalEvent.pageX,
           pageY: _originalEvent.pageY
         };
 
         // Zoom from the triggering point of the event
-        imageData.x -= offsetWidth * ((center.pageX - offset.left - x) / width);
-        imageData.y -= offsetHeight * ((center.pageY - offset.top - y) / height);
+        imageData.x -= offsetWidth * ((center.pageX - _offset.left - x) / width);
+        imageData.y -= offsetHeight * ((center.pageY - _offset.top - y) / height);
       } else if (isPlainObject(pivot) && isNumber(pivot.x) && isNumber(pivot.y)) {
         imageData.x -= offsetWidth * ((pivot.x - x) / width);
         imageData.y -= offsetHeight * ((pivot.y - y) / height);
@@ -2966,6 +2987,7 @@ var Viewer = /*#__PURE__*/function () {
     this.zooming = false;
     this.pointerMoved = false;
     this.id = getUniqueID();
+    this.lastPointerPosition = null; // Initialize the lastPointerPosition attribute
     this.init();
   }
   _createClass(Viewer, [{

--- a/dist/viewer.css
+++ b/dist/viewer.css
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2023-09-17T03:16:35.830Z
+ * Date: 2023-10-20T01:08:36.163Z
  */
 
 .viewer-zoom-in::before, .viewer-zoom-out::before, .viewer-one-to-one::before, .viewer-reset::before, .viewer-prev::before, .viewer-play::before, .viewer-next::before, .viewer-rotate-left::before, .viewer-rotate-right::before, .viewer-flip-horizontal::before, .viewer-flip-vertical::before, .viewer-fullscreen::before, .viewer-fullscreen-exit::before, .viewer-close::before {

--- a/dist/viewer.esm.js
+++ b/dist/viewer.esm.js
@@ -5,7 +5,7 @@
  * Copyright 2015-present Chen Fengyuan
  * Released under the MIT license
  *
- * Date: 2023-09-17T03:16:38.052Z
+ * Date: 2023-10-20T01:08:38.355Z
  */
 
 function ownKeys(e, r) {
@@ -1197,13 +1197,24 @@ var render = {
 
 var events = {
   bind: function bind() {
+    var _this = this;
     var options = this.options,
       viewer = this.viewer,
       canvas = this.canvas;
     var document = this.element.ownerDocument;
     addListener(viewer, EVENT_CLICK, this.onClick = this.click.bind(this));
     addListener(viewer, EVENT_DRAG_START, this.onDragStart = this.dragstart.bind(this));
-    addListener(canvas, EVENT_POINTER_DOWN, this.onPointerDown = this.pointerdown.bind(this));
+    // Use the new event binding to replace the original binding.
+    addListener(canvas, EVENT_POINTER_DOWN, function (event) {
+      _this.lastPointerPosition = {
+        x: event.pageX,
+        y: event.pageY
+      };
+      // Then call the original event handler function.
+      if (_this.pointerdown) {
+        _this.pointerdown(event);
+      }
+    });
     addListener(document, EVENT_POINTER_MOVE, this.onPointerMove = this.pointermove.bind(this));
     addListener(document, EVENT_POINTER_UP, this.onPointerUp = this.pointerup.bind(this));
     addListener(document, EVENT_KEY_DOWN, this.onKeyDown = this.keydown.bind(this));
@@ -2237,6 +2248,16 @@ var methods = {
       naturalWidth = imageData.naturalWidth,
       naturalHeight = imageData.naturalHeight;
     ratio = Math.max(0, ratio);
+
+    // After determining the zoom ratio, check if a pivot has already been provided. 
+    // If not, and we have the last pointerdown position, use it to set the pivot.
+    if (!pivot && this.lastPointerPosition) {
+      var offset = getOffset(this.viewer);
+      pivot = {
+        x: this.lastPointerPosition.x - offset.left,
+        y: this.lastPointerPosition.y - offset.top
+      };
+    }
     if (isNumber(ratio) && this.viewed && !this.played && (_zoomable || options.zoomable)) {
       if (!_zoomable) {
         var minZoomRatio = Math.max(0.01, options.minZoomRatio);
@@ -2278,15 +2299,15 @@ var methods = {
       }
       this.zooming = true;
       if (_originalEvent) {
-        var offset = getOffset(this.viewer);
+        var _offset = getOffset(this.viewer);
         var center = pointers && Object.keys(pointers).length > 0 ? getPointersCenter(pointers) : {
           pageX: _originalEvent.pageX,
           pageY: _originalEvent.pageY
         };
 
         // Zoom from the triggering point of the event
-        imageData.x -= offsetWidth * ((center.pageX - offset.left - x) / width);
-        imageData.y -= offsetHeight * ((center.pageY - offset.top - y) / height);
+        imageData.x -= offsetWidth * ((center.pageX - _offset.left - x) / width);
+        imageData.y -= offsetHeight * ((center.pageY - _offset.top - y) / height);
       } else if (isPlainObject(pivot) && isNumber(pivot.x) && isNumber(pivot.y)) {
         imageData.x -= offsetWidth * ((pivot.x - x) / width);
         imageData.y -= offsetHeight * ((pivot.y - y) / height);
@@ -2964,6 +2985,7 @@ var Viewer = /*#__PURE__*/function () {
     this.zooming = false;
     this.pointerMoved = false;
     this.id = getUniqueID();
+    this.lastPointerPosition = null; // Initialize the lastPointerPosition attribute
     this.init();
   }
   _createClass(Viewer, [{

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -21,14 +21,13 @@ export default {
 
     addListener(viewer, EVENT_CLICK, (this.onClick = this.click.bind(this)));
     addListener(viewer, EVENT_DRAG_START, (this.onDragStart = this.dragstart.bind(this)));
-    // addListener(canvas, EVENT_POINTER_DOWN, (this.onPointerDown = this.pointerdown.bind(this)));
-    // 使用新的事件绑定替代原有的绑定
+    // Use the new event binding to replace the original binding.
     addListener(canvas, EVENT_POINTER_DOWN, (event) => {
       this.lastPointerPosition = {
         x: event.pageX,
         y: event.pageY
       };
-      // 然后调用原有的事件处理函数
+      // Then call the original event handler function.
       if (this.pointerdown) {
         this.pointerdown(event);
       }

--- a/src/js/events.js
+++ b/src/js/events.js
@@ -21,7 +21,18 @@ export default {
 
     addListener(viewer, EVENT_CLICK, (this.onClick = this.click.bind(this)));
     addListener(viewer, EVENT_DRAG_START, (this.onDragStart = this.dragstart.bind(this)));
-    addListener(canvas, EVENT_POINTER_DOWN, (this.onPointerDown = this.pointerdown.bind(this)));
+    // addListener(canvas, EVENT_POINTER_DOWN, (this.onPointerDown = this.pointerdown.bind(this)));
+    // 使用新的事件绑定替代原有的绑定
+    addListener(canvas, EVENT_POINTER_DOWN, (event) => {
+      this.lastPointerPosition = {
+        x: event.pageX,
+        y: event.pageY
+      };
+      // 然后调用原有的事件处理函数
+      if (this.pointerdown) {
+        this.pointerdown(event);
+      }
+    });
     addListener(document, EVENT_POINTER_MOVE, (this.onPointerMove = this.pointermove.bind(this)));
     addListener(document, EVENT_POINTER_UP, (this.onPointerUp = this.pointerup.bind(this)));
     addListener(document, EVENT_KEY_DOWN, (this.onKeyDown = this.keydown.bind(this)));

--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -717,6 +717,15 @@ export default {
 
     ratio = Math.max(0, ratio);
 
+    // 在确定了缩放比率后，我们检查是否已经提供了一个pivot。如果没有，并且我们有最后一个pointerdown的位置，我们使用它来设置pivot。
+    if (!pivot && this.lastPointerPosition) {
+      const offset = getOffset(this.viewer);
+      pivot = {
+        x: this.lastPointerPosition.x - offset.left,
+        y: this.lastPointerPosition.y - offset.top
+      };
+    }  
+
     if (isNumber(ratio) && this.viewed && !this.played && (_zoomable || options.zoomable)) {
       if (!_zoomable) {
         const minZoomRatio = Math.max(0.01, options.minZoomRatio);

--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -717,7 +717,8 @@ export default {
 
     ratio = Math.max(0, ratio);
 
-    // 在确定了缩放比率后，我们检查是否已经提供了一个pivot。如果没有，并且我们有最后一个pointerdown的位置，我们使用它来设置pivot。
+    // After determining the zoom ratio, check if a pivot has already been provided. 
+    // If not, and we have the last pointerdown position, use it to set the pivot.
     if (!pivot && this.lastPointerPosition) {
       const offset = getOffset(this.viewer);
       pivot = {

--- a/src/js/viewer.js
+++ b/src/js/viewer.js
@@ -86,7 +86,7 @@ class Viewer {
     this.zooming = false;
     this.pointerMoved = false;
     this.id = getUniqueID();
-    this.lastPointerPosition = null;  // 初始化 lastPointerPosition 属性
+    this.lastPointerPosition = null;  // Initialize the lastPointerPosition attribute
     this.init();
   }
 

--- a/src/js/viewer.js
+++ b/src/js/viewer.js
@@ -86,6 +86,7 @@ class Viewer {
     this.zooming = false;
     this.pointerMoved = false;
     this.id = getUniqueID();
+    this.lastPointerPosition = null;  // 初始化 lastPointerPosition 属性
     this.init();
   }
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

This allows the zoom origin to behave as the follows when using icons in the control bar to zoom image:
- If the image has been clicked by the mouse or been touched, the zoom origin will be the last place of the mouse or the touch point.
- Otherwise, the zoom origin will be the center of the image.

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
