### PR TITLE
fix:temporary image misalignment when loading image slowly

### DIFF
--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -232,6 +232,16 @@ export default {
    * @type {Function}
    */
   ready: null,
+  /**
+   * Hide images until they are successfully loaded
+   * @type {boolean}
+   */
+  hideImageBeforeLoaded: false,
+  /**
+   * Display images that have not been fully loaded after the time has passed
+   * @type {number}
+   */
+  timeout: 1000,
   show: null,
   shown: null,
   hide: null,

--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -369,10 +369,13 @@ export default {
       }
 
       // Make the image visible if it fails to load within 1s
-      this.timeout = setTimeout(() => {
-        removeClass(image, CLASS_INVISIBLE);
-        this.timeout = false;
-      }, 1000);
+      const { timeout, hideImageBeforeLoaded } = this.options;
+      if (!hideImageBeforeLoaded) {
+        this.timeout = setTimeout(() => {
+          removeClass(image, CLASS_INVISIBLE);
+          this.timeout = false;
+        }, timeout);
+      }
     }
 
     return this;


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [ ] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
If in a slow network environment or with large image resources, it may cause the image to temporarily appear and be misaligned after one second of loading. This is because setTimeout is used as a fallback in the code. But this misalignment and flickering can lead to a bad experience, especially when the image loading time is between 1 s and 2 s. So I think maybe we should increase the configuration to prevent this behavior or allow developers to configure time delays themselves
After 1 second
<img width="1423" alt="image" src="https://github.com/fengyuanchen/viewerjs/assets/76039018/d4667c04-e028-4976-a1c6-e89879ada546">

The situation in the above picture will continue until the final display of the image
<img width="975" alt="image" src="https://github.com/fengyuanchen/viewerjs/assets/76039018/315f11d6-8a2e-442e-836c-58823b85c835">






