### PR TITLE
feat: add ResizeObserver support for inline mode to handle parent container resize

### DIFF
--- a/src/js/methods.js
+++ b/src/js/methods.js
@@ -1234,6 +1234,11 @@ export default {
       return this;
     }
 
+    if (this.parentResizeObserver) {
+      this.parentResizeObserver.disconnect();
+      this.parentResizeObserver = null;
+    }
+
     this.destroyed = true;
 
     if (this.ready) {

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -58,6 +58,8 @@ export default {
       };
 
       this.parentData = viewerData;
+
+      this.initParentResizeObserver();
     }
 
     if (this.fulled || !viewerData) {
@@ -71,6 +73,44 @@ export default {
     if (this.options.inline && !this.fulled) {
       setStyle(this.viewer, this.viewerData);
     }
+  },
+
+  initParentResizeObserver() {
+    const { parent, options } = this;
+
+    if (this.parentResizeObserver) {
+      this.parentResizeObserver.disconnect();
+      this.parentResizeObserver = null;
+    }
+
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    this.parentResizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+
+      const { width, height } = entry.contentRect;
+      const newViewerData = {
+        width: Math.max(width, options.minWidth),
+        height: Math.max(height, options.minHeight),
+      };
+
+      if (newViewerData.width !== this.viewerData.width
+          || newViewerData.height !== this.viewerData.height) {
+        this.viewerData = assign({}, newViewerData);
+        this.renderViewer();
+
+        if (this.viewed) {
+          this.initImage(() => {
+            this.renderImage();
+          });
+        }
+      }
+    });
+
+    this.parentResizeObserver.observe(parent);
   },
 
   initList() {

--- a/test/specs/resizeobserver.spec.js
+++ b/test/specs/resizeobserver.spec.js
@@ -1,0 +1,175 @@
+describe('ResizeObserver (inline mode)', () => {
+  it('should create parentResizeObserver in inline mode', (done) => {
+    const image = window.createImage();
+    const viewer = new Viewer(image, {
+      inline: true,
+
+      ready() {
+        expect(viewer.parentResizeObserver).to.be.an.instanceof(ResizeObserver);
+        done();
+      },
+    });
+  });
+
+  it('should not create parentResizeObserver in modal mode', (done) => {
+    const image = window.createImage();
+    const viewer = new Viewer(image, {
+      shown() {
+        expect(viewer.parentResizeObserver).to.be.undefined;
+        viewer.hide(true);
+        done();
+      },
+    });
+
+    viewer.show();
+  });
+
+  it('should update viewerData when parent container resizes', (done) => {
+    const container = window.createContainer();
+    const image = document.createElement('img');
+
+    image.src = '/base/docs/images/tibet-1.jpg';
+    container.appendChild(image);
+
+    container.style.width = '400px';
+    container.style.height = '300px';
+
+    const viewer = new Viewer(image, {
+      inline: true,
+
+      ready() {
+        const initialWidth = viewer.viewerData.width;
+        const initialHeight = viewer.viewerData.height;
+
+        expect(initialWidth).to.equal(400);
+        expect(initialHeight).to.equal(300);
+
+        container.style.width = '600px';
+        container.style.height = '500px';
+
+        setTimeout(() => {
+          expect(viewer.viewerData.width).to.equal(600);
+          expect(viewer.viewerData.height).to.equal(500);
+          done();
+        }, 100);
+      },
+    });
+  });
+
+  it('should respect minWidth and minHeight when resizing', (done) => {
+    const container = window.createContainer();
+    const image = document.createElement('img');
+
+    image.src = '/base/docs/images/tibet-1.jpg';
+    container.appendChild(image);
+
+    container.style.width = '400px';
+    container.style.height = '300px';
+
+    const viewer = new Viewer(image, {
+      inline: true,
+      minWidth: 500,
+      minHeight: 400,
+
+      ready() {
+        expect(viewer.viewerData.width).to.equal(500);
+        expect(viewer.viewerData.height).to.equal(400);
+
+        container.style.width = '300px';
+        container.style.height = '200px';
+
+        setTimeout(() => {
+          expect(viewer.viewerData.width).to.equal(500);
+          expect(viewer.viewerData.height).to.equal(400);
+          done();
+        }, 100);
+      },
+    });
+  });
+
+  it('should clean up parentResizeObserver on destroy', (done) => {
+    const image = window.createImage();
+    const viewer = new Viewer(image, {
+      inline: true,
+
+      ready() {
+        expect(viewer.parentResizeObserver).to.be.an.instanceof(ResizeObserver);
+        viewer.destroy();
+        expect(viewer.parentResizeObserver).to.be.null;
+        done();
+      },
+    });
+  });
+
+  it('should handle multiple resize events', (done) => {
+    const container = window.createContainer();
+    const image = document.createElement('img');
+
+    image.src = '/base/docs/images/tibet-1.jpg';
+    container.appendChild(image);
+
+    container.style.width = '400px';
+    container.style.height = '300px';
+
+    let resizeCount = 0;
+    const viewer = new Viewer(image, {
+      inline: true,
+
+      ready() {
+        const originalRenderViewer = viewer.renderViewer.bind(viewer);
+        viewer.renderViewer = function () {
+          resizeCount += 1;
+          return originalRenderViewer();
+        };
+
+        container.style.width = '500px';
+
+        setTimeout(() => {
+          container.style.height = '400px';
+
+          setTimeout(() => {
+            container.style.width = '600px';
+            container.style.height = '500px';
+
+            setTimeout(() => {
+              expect(resizeCount).to.be.at.least(2);
+              done();
+            }, 100);
+          }, 50);
+        }, 50);
+      },
+    });
+  });
+
+  it('should re-render image when container resizes and image is viewed', (done) => {
+    const container = window.createContainer();
+    const image = document.createElement('img');
+
+    image.src = '/base/docs/images/tibet-1.jpg';
+    container.appendChild(image);
+
+    container.style.width = '400px';
+    container.style.height = '300px';
+
+    let initImageCalled = false;
+    const viewer = new Viewer(image, {
+      inline: true,
+
+      viewed() {
+        const originalInitImage = viewer.initImage.bind(viewer);
+        viewer.initImage = function (callback) {
+          initImageCalled = true;
+          return originalInitImage(callback);
+        };
+
+        container.style.width = '600px';
+        container.style.height = '500px';
+
+        setTimeout(() => {
+          expect(initImageCalled).to.be.true;
+          done();
+        }, 100);
+      },
+    });
+  });
+});


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**Summary**

When using inline mode, the viewer initializes its size based on the parent container's offsetWidth/offsetHeight. However, if the parent container's size is not determined at initialization time (e.g., using percentage height or async data rendering), the viewer will have incorrect dimensions.

This PR adds ResizeObserver support to automatically update the viewer's size when the parent container resizes, solving the issue where only window resize was previously handled.

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

If changing the UI of the default theme, please provide the **before/after** screenshot:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)

You have tested in the following browsers: (Providing a detailed version will be better.)

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [x] Edge
- [ ] IE

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature
- [ ] Related documents have been updated
- [x] Related tests have been updated

To avoid wasting your time, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**

Changes:
- Add initParentResizeObserver() method in render.js
- Call initParentResizeObserver() in initViewer() when inline mode is enabled
- Disconnect ResizeObserver in destroy() method to prevent memory leaks